### PR TITLE
Fixed social links opening in New Window

### DIFF
--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -264,12 +264,17 @@ function UserPage() {
       }
 
       // Open share window only after everything is ready
-      window.open(shareLink, "_blank", "width=600,height=400");
+      window.open(shareLink, "_blank");
     } catch (err) {
       console.error("Error sharing profile:", err);
       setIsGenerating(false);
     }
   };
+
+
+
+
+
 
   // Show loading while checking Clerk auth status or user registration
   if (!isLoaded || checkingRegistration) {

--- a/src/components/GitHubProfileCard.tsx
+++ b/src/components/GitHubProfileCard.tsx
@@ -310,7 +310,7 @@ const GitHubProfileCard: React.FC<GitHubProfileCardProps> = ({
       }
 
       // Open share window only after everything is ready
-      window.open(shareLink, "_blank", "width=600,height=400");
+      window.open(shareLink, "_blank");
     } catch (err) {
       console.error("Error sharing profile:", err);
       setIsGenerating(false);


### PR DESCRIPTION
## Description

Changed the share link behavior to open in a **new tab** instead of a new window.

## Fixes

Closes #46

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

---

Made changes in `handleShare` function in `GitHubProfileCard.tsx` and updated `page.tsx` for user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated sharing behavior to open links in a new tab using the browser’s default window size, removing fixed 600x400 popups.
  * Applied consistently across user profile pages and GitHub profile cards for a uniform sharing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->