### PR TITLE
Add Bottom to Top Button #53

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { dark } from "@clerk/themes";
 import UserSync from "@/components/UserSync";
 import { Toaster } from "sonner";
 import { ProductHuntBanner } from "@/components/ProductHuntBanner";
+import ScrollToTop from "@/components/ScrollToTop";
 
 const monaSans = Mona_Sans({
   subsets: ["latin"],
@@ -221,7 +222,10 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <ThemeAwareProviders>{children}</ThemeAwareProviders>
+          <ThemeAwareProviders>
+            {children}
+            <ScrollToTop />
+          </ThemeAwareProviders>
 
           <Analytics />
         </ThemeProvider>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+const ScrollToTop = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.pageYOffset > 100) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <button
+      className={`fixed cursor-pointer bottom-4 right-4 w-12 h-12 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-full shadow-lg hover:shadow-xl hover:from-blue-600 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all duration-300 transform hover:scale-110 ${
+        isVisible ? "opacity-100" : "opacity-0"
+      }`}
+      onClick={scrollToTop}
+      style={{ pointerEvents: isVisible ? "auto" : "none", zIndex: 1000 }} // Z-index 1000 set kiya
+      aria-label="Scroll to top"
+    >
+      <svg
+        className="w-6 h-6 mx-auto"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M5 10l7-7m0 0l7 7m-7-7v18"
+        />
+      </svg>
+    </button>
+  );
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
Added a Bottom to Top button that appears after scrolling 100px, with improved styling (gradient, shadow, hover effects, SVG icon), increased z-index to 1000, and theme support. Integrated into root layout for multiple pages. Tested on home and profile pages across mobile and desktop views.
Fixes #53
<img width="1918" height="902" alt="bottomtotop" src="https://github.com/user-attachments/assets/90cdc6c3-0f24-4cbe-b175-24c5928c6d2d" />
