### PR TITLE
Fix UI issue for "Get roasted in under 30 seconds" modal

### DIFF
--- a/src/components/home/how-it-works.tsx
+++ b/src/components/home/how-it-works.tsx
@@ -51,7 +51,7 @@ export const HowItWorks = () => {
 
   return (
     <section
-      className="py-12 sm:py-24 bg-card relative overflow-hidden"
+      className="py-12 z-0 sm:py-24 bg-card relative overflow-hidden"
       id="how-it-works"
     >
       {/* Background Grid */}


### PR DESCRIPTION
## Description

Fix UI layout issue where the "Get roasted in under 30 seconds" modal was overlapped by the section below. Added `z-0` to the section to prevent layout overlap.

## Fixes

Closes #104 

## Video

https://github.com/user-attachments/assets/20275348-516a-4ce5-a780-b208a1c43e20

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I followed the code style
- [x] I tested the changes locally
- [x] My changes work on mobile, tablet, and desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved a visual layering issue on the Home “How it works” section where overlapping elements could obscure content. The section now consistently renders beneath floating components, improving readability and interaction across screen sizes.
- Style
  - Adjusted stacking behavior to ensure predictable layering of the section within the page layout, delivering a more stable and polished visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->